### PR TITLE
feat: adiciona seção de Projetos no portfólio

### DIFF
--- a/src/components/ui/projects-section.tsx
+++ b/src/components/ui/projects-section.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { ExternalLink } from "lucide-react"
+
+interface Project {
+  title: string
+  description: string
+  url: string
+}
+
+const projects: Project[] = [
+  {
+    title: "Portfólio Pessoal",
+    description: "Meu portfólio em React, TS e Tailwind.",
+    url: "https://github.com/GuMoBu488/portfolio"
+  },
+  {
+    title: "App de Tarefas",
+    description: "Um app simples de gerenciamento de tarefas.",
+    url: "https://github.com/GuMoBu488/todo-app"
+  }
+]
+
+export const ProjectsSection: React.FC = () => {
+  return (
+    <section id="projects" className="py-20 bg-gray-50">
+      <div className="container mx-auto px-6 text-center">
+        <h2 className="text-3xl font-bold mb-10">Projetos</h2>
+
+        <div className="grid md:grid-cols-2 gap-8">
+          {projects.map((project, index) => (
+            <Card key={index} className="hover:shadow-lg transition-all">
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-xl mb-2">{project.title}</h3>
+                <p className="text-gray-700 mb-4">{project.description}</p>
+                <a
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center text-blue-500 hover:underline"
+                >
+                  Ver projeto <ExternalLink className="ml-2 h-4 w-4"/>
+                </a>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,7 @@
 import { Navbar } from "@/components/navbar"
 import { HeroSection } from "@/components/hero-section"
 import { AboutSection } from "@/components/about-section"
-import { ProjectsSection } from "@/components/projects-section"
+import { ProjectsSection } from "@/components/ui/projects-section" // <-- Import do novo componente
 import { SkillsSection } from "@/components/skills-section"
 import { ContactSection } from "@/components/contact-section"
 import { Footer } from "@/components/footer"
@@ -13,13 +13,13 @@ const Index = () => {
       <main>
         <HeroSection />
         <AboutSection />
-        <ProjectsSection />
+        <ProjectsSection /> {/* Seção de Projetos adicionada */}
         <SkillsSection />
         <ContactSection />
       </main>
       <Footer />
     </div>
-  );
-};
+  )
+}
 
-export default Index;
+export default Index


### PR DESCRIPTION
Esta PR adiciona a seção "Projetos" na página principal do portfólio. A seção inclui:

- Cards de projetos com título, descrição e link para GitHub ou demo
- Estrutura responsiva com Tailwind CSS
- Integração direta na página principal (Index) entre AboutSection e SkillsSection

Objetivo: mostrar aos visitantes os projetos do portfólio de forma clara, visual e navegável, destacando experiência em desenvolvimento web e projetos pessoais.

Notas:
- Os projetos são exibidos em grid responsivo (2 colunas em desktop, 1 coluna em mobile)
- Cada card possui link externo com ícone indicando que abre em nova aba
